### PR TITLE
Annotate Api::Problem error with thiserror::transparent

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ pub enum Error {
     /// An JSON problem as returned by the ACME server
     ///
     /// RFC 8555 uses problem documents as described in RFC 7807.
-    #[error("API error: {0}")]
+    #[error(transparent)]
     Api(#[from] Problem),
     /// Failed to base64-decode data
     #[error("base64 decoding failed: {0}")]


### PR DESCRIPTION
Error variant `Api::Problem` prints "API error: {problem}" however the Problem struct has display impl that starts by printing "API error". Together this results in "API error: API error" followed by the details.

This fixes that by annotating `Api::Problem` with `thiserror`'s `transparent` attribute which forwards the display impl to the underlying types display impl.